### PR TITLE
fix: fix RAMsim3 finish

### DIFF
--- a/src/cosimulation.cc
+++ b/src/cosimulation.cc
@@ -19,6 +19,7 @@ ComplexCoDRAMsim3::ComplexCoDRAMsim3(const std::string &config_file, const std::
 ComplexCoDRAMsim3::~ComplexCoDRAMsim3() {
     memory->PrintStats();
     delete memory;
+    memory = NULL;
 }
 
 void ComplexCoDRAMsim3::tick() {


### PR DESCRIPTION
ram deallocation that does not point to NULL will cause unnecessary errors, such as reinitializing the wild pointer